### PR TITLE
Updated sendMessage

### DIFF
--- a/src/main/java/com/github/cheesesoftware/PowerfulPerms/Bungee/PowerfulPerms.java
+++ b/src/main/java/com/github/cheesesoftware/PowerfulPerms/Bungee/PowerfulPerms.java
@@ -26,6 +26,7 @@ import com.google.common.io.ByteStreams;
 
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.PermissionCheckEvent;
 import net.md_5.bungee.api.event.TabCompleteEvent;
@@ -291,7 +292,7 @@ public class PowerfulPerms extends Plugin implements Listener, PowerfulPermsPlug
             commandSender = ProxyServer.getInstance().getPlayer(name);
 
         if (commandSender != null)
-            commandSender.sendMessage(PermissionManagerBase.pluginPrefixShort + message);
+            commandSender.sendMessage(TextComponent.fromLegacyText(PermissionManagerBase.pluginPrefixShort + message));
     }
 
     @Override


### PR DESCRIPTION
sendMessage(String message) is deprecated as of
https://github.com/SpigotMC/BungeeCord/commit/2c8b15cb1ef865058badc018cfeb124ab98fdf85

https://ci.md-5.net/job/BungeeCord/ws/api/target/apidocs/net/md_5/bungee/api/CommandSender.html#sendMessage-java.lang.String-